### PR TITLE
Update 0.4.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,6 @@
 {% set name = "crashtest" %}
 {% set version = "0.4.1" %}
 
-
 package:
   name: {{ name|lower }}
   version: {{ version }}


### PR DESCRIPTION
[Upstream](https://github.com/sdispater/crashtest)
[Changelog](https://github.com/sdispater/crashtest/releases)

### Actions
- Update version number and sha256
- Remove noarch
- Lower build number
- Linter fixes
- Recipe cleanup