### PR TITLE
crashtest 0.4.1: Rebuild for py313 on win-64

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,11 +10,11 @@ source:
   sha256: 80d7b1f316ebfbd429f648076d6275c877ba30ba48979de4191714a75266f0ce
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<38]
   script:
     - rm -f pyproject.toml
-    - {{ PYTHON }} -m pip install --no-deps . -vv
+    - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
 requirements:
   host:


### PR DESCRIPTION
Missing py313 artifacts on win-64:
```
conda search crashtest --subdir=win-64
Loading channels: done
# Name                       Version           Build  Channel
crashtest                      0.3.0            py_0  pkgs/main
crashtest                      0.3.1            py_0  pkgs/main
crashtest                      0.3.1    pyhd3eb1b0_1  pkgs/main
crashtest                      0.4.1 py310haa95532_0  pkgs/main
crashtest                      0.4.1 py311haa95532_0  pkgs/main
crashtest                      0.4.1 py312haa95532_0  pkgs/main
crashtest                      0.4.1  py38haa95532_0  pkgs/main
crashtest                      0.4.1  py39haa95532_0  pkgs/main 
```